### PR TITLE
fix: permit inline Tailwind config in CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; img-src 'self' https: data:; media-src 'self' https: data:; script-src 'self' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+    Content-Security-Policy = "default-src 'self'; img-src 'self' https: data:; media-src 'self' https: data:; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com; style-src 'self' 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
     X-Content-Type-Options = "nosniff"
     X-Frame-Options = "DENY"
     Referrer-Policy = "strict-origin-when-cross-origin"


### PR DESCRIPTION
## Summary
- allow inline scripts in Content-Security-Policy so Tailwind config runs

## Testing
- `npm test` *(fails: ENOENT cannot open package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d1f6b5d8832b8771c0d6e65d7e6c